### PR TITLE
Enable clang-19 testing on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         config:
           - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17-toolchain.cmake", clang_version: 17, installed_clang_version: 14, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18-toolchain.cmake", clang_version: 18, installed_clang_version: 14, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          # Note: clang-19 + Asan setup causes errors on some platforms. Temporary skip some checks via .asan_options.
+          - {name: "Ubuntu Clang 19", os: ubuntu-24.04, toolchain: "clang-19-toolchain.cmake", clang_version: 19, installed_clang_version: 14, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" ", asan_options: "new_delete_type_mismatch=0"}
           - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13-toolchain.cmake", clang_version: 17, installed_clang_version: 14, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14-toolchain.cmake", clang_version: 17, installed_clang_version: 14, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
     steps:
@@ -53,10 +55,12 @@ jobs:
       - name: Install GCC 14
         if: matrix.config.name == 'Ubuntu GCC 14'
         run: |
+          set -x
           sudo apt update
           sudo apt-get install g++-14
       - name: Configure
         run: |
+          set -x
           rm -rf .build
           mkdir -p .build
           cd .build
@@ -65,8 +69,11 @@ jobs:
           cmake ${{ matrix.config.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=etc/${{ matrix.config.toolchain }} -B . -S ..
       - name: Build
         run: |
+          set -x
           cmake --build .build --config Asan --target all -- -k 0
       - name: Test
         run: |
+          set -x
           cd .build
-          ctest --output-on-failure
+          [[ ! -z "${{ matrix.config.asan_options }}" ]]  && export ASAN_OPTIONS="${{ matrix.config.asan_options }}"
+          ctest --build-config Asan --output-on-failure

--- a/docs/debug-ci.md
+++ b/docs/debug-ci.md
@@ -1,0 +1,33 @@
+# Debug CI
+
+<!--
+SPDX-License-Identifier: 2.0 license with LLVM exceptions
+-->
+
+## CI flows
+
+CI flows are found in [.github/workflows/](.github/workflows/). Usually, they are run when generating a Git Action (e.g. at `push`).
+
+WIP to add flows for tests, linting etc.
+
+## Run CI Flows on Local Setup
+
+We can use [nektos/act](https://github.com/nektos/act) to simulate and test Git Actions on local setup.
+Setup and tutorial on [nektosact.com/](https://nektosact.com/).
+
+```shell
+# Check available jobs
+$ sudo act --container-architecture linux/amd64 --list
+Stage  Job ID  Job name                   Workflow name  Workflow file  Events           
+0      build   ${{ matrix.config.name }}  CI Tests       ci.yml         pull_request,push
+
+# Run all CI jobs
+Optional26 $ sudo act -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04 --container-architecture linux/amd64 push
+[CI Tests/Ubuntu Clang 18-2] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-24.04
+[CI Tests/Ubuntu Clang 19-3] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-24.04
+[CI Tests/Ubuntu Clang 17-1] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-24.04
+[CI Tests/Ubuntu GCC 14-5  ] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-24.04
+[CI Tests/Ubuntu GCC 13-4  ] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-24.04
+...
+
+```

--- a/src/Beman/Optional26/CMakeLists.txt
+++ b/src/Beman/Optional26/CMakeLists.txt
@@ -48,4 +48,8 @@ target_link_libraries(optional_test gtest)
 target_link_libraries(optional_test gtest_main)
 
 include(GoogleTest)
-gtest_discover_tests(optional_test)
+
+# Note: clang-19 + gtest_discover_tests + Asan setup causes errors on some platforms.
+# Temporary switch to gtest_add_tests and skip some Asan checks.
+enable_testing()
+gtest_add_tests(optional_test "" AUTO)


### PR DESCRIPTION
Enable clang-19 testing on CI ( #1 )

It seems that the previous errors that we had with running clang-19 + Asan are connected to gtest. Check [gist](https://gist.github.com/neatudarius/87cbb37a1821e4dcbf773906fb15f8ae): 
```shell
#10 0x55f30b5bbd1e in __cxx_global_var_init /home/runner/work/Beman.Optional26/Beman.Optional26/src/Beman/Optional26/tests/optional.t.cpp:14:1
```
Literally here we just test gtest :( I also created an executable with a single file (outside the Beman.Optional26 tree) and got the same results.

Found the fix looking through some posts:
* https://github.com/llvm/llvm-project/issues/58404
* https://stackoverflow.com/questions/41552966/getting-new-delete-type-mismatch-from-asan
