### PR TITLE
Avoid reopening namespace `std`

### DIFF
--- a/include/Beman/Optional26/optional.hpp
+++ b/include/Beman/Optional26/optional.hpp
@@ -6,7 +6,6 @@
 
 /*
 22.5.2 Header <optional> synopsis[optional.syn]
-🔗
 
 #include <compare>              // see [compare.syn]
 
@@ -210,22 +209,19 @@ class optional;
 
 } // namespace beman::optional26
 
-namespace std {
 // Since P3168R2: Give std::optional Range Support.
 template <typename T>
-inline constexpr bool ranges::enable_view<beman::optional26::optional<T>> = true;
+inline constexpr bool std::ranges::enable_view<beman::optional26::optional<T>> = true;
 
 // TODO: document why this is needed.
 template <typename T>
-inline constexpr bool ranges::enable_borrowed_range<beman::optional26::optional<T&>> = true;
+inline constexpr bool std::ranges::enable_borrowed_range<beman::optional26::optional<T&>> = true;
 
 // Since P3168R2: Give std::optional Range Support.
 #if defined(__cpp_lib_format_ranges)
 template <class T>
-inline constexpr auto format_kind<beman::optional26::optional<T>> = range_format::disabled;
+inline constexpr auto std::format_kind<beman::optional26::optional<T>> = range_format::disabled;
 #endif
-
-} // namespace std
 
 namespace beman::optional26 {
 template <class T>


### PR DESCRIPTION
Following the suggestion in [_Don’t reopen `namespace std`_](https://quuxplusone.github.io/blog/2021/10/27/dont-reopen-namespace-std/).

The change also works around a bug of MSVC (reduced and [reported on DevCom](https://developercommunity.visualstudio.com/t/MSVC-doesnt-accept-specialization-defin/10732088)).

Godbolt links:
- Before: https://godbolt.org/z/1bf1458Pf
- After: https://godbolt.org/z/1eanosrob

Drive-by: Remove emoji `🔗` from the synopsis comments, which seems to be copied from https://eel.is/c++draft/optional.syn.