### PR TITLE
Fix some bugs in optional<T&>; add tests for them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI Tests
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,7 @@
 name: pre-commit
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]

--- a/include/Beman/Optional26/optional.hpp
+++ b/include/Beman/Optional26/optional.hpp
@@ -339,7 +339,7 @@ class optional {
         }
     }
 
-    constexpr optional(const optional&)
+    optional(const optional&)
         requires std::is_copy_constructible_v<T> && std::is_trivially_copy_constructible_v<T>
     = default;
 
@@ -352,7 +352,7 @@ class optional {
         }
     }
 
-    constexpr optional(optional&&)
+    optional(optional&&)
         requires std::is_move_constructible_v<T> && std::is_trivially_move_constructible_v<T>
     = default;
 
@@ -430,7 +430,7 @@ class optional {
         return *this;
     }
 
-    constexpr optional& operator=(const optional&)
+    optional& operator=(const optional&)
         requires std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T> &&
                      std::is_trivially_copy_constructible_v<T> && std::is_trivially_copy_assignable_v<T>
     = default;
@@ -448,7 +448,7 @@ class optional {
         return *this;
     }
 
-    constexpr optional& operator=(optional&&)
+    optional& operator=(optional&&)
         requires std::is_move_constructible_v<T> && std::is_move_assignable_v<T> &&
                      std::is_trivially_move_constructible_v<T> && std::is_trivially_move_assignable_v<T>
     = default;
@@ -1016,17 +1016,17 @@ class optional<T&> {
     // constexpr void reset() noexcept;
 
   private:
-    T* value_; // exposition only
+    T* value_ = nullptr; // exposition only
 
   public:
     //  \rSec3[optional.ctor]{Constructors}
 
-    constexpr optional() noexcept : value_(nullptr) {}
+    optional() = default;
 
     constexpr optional(nullopt_t) noexcept : value_(nullptr) {}
 
-    constexpr optional(const optional& rhs) noexcept = default;
-    constexpr optional(optional&& rhs) noexcept      = default;
+    optional(const optional& rhs) = default;
+    optional(optional&& rhs)      = default;
 
     template <class U = T>
         requires(!detail::is_optional<std::decay_t<U>>)
@@ -1046,7 +1046,7 @@ class optional<T&> {
 
     //  \rSec3[optional.dtor]{Destructor}
 
-    constexpr ~optional() = default;
+    ~optional() = default;
 
     // \rSec3[optional.assign]{Assignment}
 
@@ -1055,8 +1055,8 @@ class optional<T&> {
         return *this;
     }
 
-    constexpr optional& operator=(const optional& rhs) noexcept = default;
-    constexpr optional& operator=(optional&& rhs) noexcept      = default;
+    optional& operator=(const optional&) = default;
+    optional& operator=(optional&&)      = default;
 
     template <class U = T>
         requires(!detail::is_optional<std::decay_t<U>>)
@@ -1078,7 +1078,7 @@ class optional<T&> {
     }
 
     template <class U>
-    constexpr optional& operator=(optional<U>&& rhs) = delete;
+    optional& operator=(optional<U>&& rhs) = delete;
 
     template <class U>
         requires(!detail::is_optional<std::decay_t<U>>)

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -118,6 +118,22 @@ TEST(OptionalTest, NonDefaultConstruct) {
     std::ignore = v2;
 }
 
+TEST(OptionalTest, OptionalOfOptional) {
+    using O = beman::optional26::optional<int>;
+    O                              o;
+    beman::optional26::optional<O> oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_FALSE(oo1->has_value());
+
+    beman::optional26::optional<O> oo2 = std::move(o);
+    EXPECT_TRUE(oo2.has_value());
+    oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_FALSE(oo2->has_value());
+}
+
 TEST(OptionalTest, AssignmentValue) {
     beman::optional26::optional<int> o1 = 42;
     beman::optional26::optional<int> o2 = 12;

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -123,7 +123,7 @@ TEST(OptionalTest, AssignmentValue) {
     beman::optional26::optional<int> o2 = 12;
     beman::optional26::optional<int> o3;
 
-    o1 = o1;
+    o1 = static_cast<beman::optional26::optional<int>&>(o1);
     EXPECT_TRUE(*o1 == 42);
 
     o1 = o2;

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -132,6 +132,23 @@ TEST(OptionalTest, OptionalOfOptional) {
     oo2 = o;
     EXPECT_TRUE(oo2.has_value());
     EXPECT_FALSE(oo2->has_value());
+
+    // emplace constructs the inner optional
+    oo2.emplace(beman::optional26::nullopt);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_FALSE(oo2->has_value());
+    oo2.emplace(beman::optional26::in_place, 41);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(oo2.value() == 41);
+    oo2.emplace(42);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(oo2.value() == 42);
+    oo2.emplace(o);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_FALSE(oo2->has_value());
+    oo2.emplace(O(43));
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(oo2.value() == 43);
 }
 
 TEST(OptionalTest, AssignmentValue) {

--- a/src/Beman/Optional26/tests/optional_constexpr.t.cpp
+++ b/src/Beman/Optional26/tests/optional_constexpr.t.cpp
@@ -109,6 +109,7 @@ class NoDefault {
 
   public:
     constexpr NoDefault(int v) : v_(v) {}
+    constexpr int value() const { return v_; }
 };
 } // namespace
 
@@ -126,7 +127,7 @@ consteval bool testConstexprAssignmentValue() {
     beman::optional26::optional<int> o2     = 12;
     beman::optional26::optional<int> o3;
 
-    o1 = o1;
+    o1 = static_cast<beman::optional26::optional<int>&>(o1);
     retval &= (*o1 == 42);
 
     o1 = o2;

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -81,10 +81,11 @@ TEST(OptionalRefTest, Assignment) {
     EXPECT_FALSE(empty);
     i2 = empty;
     EXPECT_FALSE(i2);
-    int eight = 8;
-    empty.emplace(eight);
+    int  eight  = 8;
+    int& result = empty.emplace(eight);
     EXPECT_TRUE(empty);
     EXPECT_EQ(empty, 8);
+    EXPECT_EQ(&result, &eight);
 }
 
 TEST(OptionalRefTest, RelationalOps) {
@@ -652,10 +653,16 @@ TEST(OptionalRefTest, OptionalOfOptional) {
     oo1 = o;
     EXPECT_TRUE(oo1.has_value());
     EXPECT_TRUE(&oo1.value() == &o);
+    oo1.emplace(o); // emplace, like assignment, binds the reference
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_TRUE(&oo1.value() == &o);
 
     beman::optional26::optional<const O&> oo2 = o;
     EXPECT_TRUE(oo2.has_value());
     oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(&oo2.value() == &o);
+    oo2.emplace(o);
     EXPECT_TRUE(oo2.has_value());
     EXPECT_TRUE(&oo2.value() == &o);
 }

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -643,3 +643,43 @@ TEST(OptionalRefTest, ConstructFromOptional) {
     beman::optional26::optional<const base&> optional_base_const_ref2{engaged_derived};
     EXPECT_TRUE(optional_base_const_ref2.has_value());
 }
+
+TEST(OptionalRefTest, OptionalOfOptional) {
+    using O = beman::optional26::optional<int>;
+    O                               o;
+    beman::optional26::optional<O&> oo = o;
+    EXPECT_TRUE(oo.has_value());
+    oo = o;
+    EXPECT_TRUE(oo.has_value());
+    EXPECT_TRUE(&oo.value() == &o);
+}
+
+TEST(OptionalRefTest, ConstructFromReferenceWrapper) {
+    using O = beman::optional26::optional<int>;
+    O o;
+
+    beman::optional26::optional<O&> oo1 = std::ref(o);
+    EXPECT_TRUE(oo1.has_value());
+    oo1 = std::ref(o);
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_TRUE(&oo1.value() == &o);
+
+    auto                            lvalue_refwrapper = std::ref(o);
+    beman::optional26::optional<O&> oo2               = lvalue_refwrapper;
+    EXPECT_TRUE(oo2.has_value());
+    oo2 = lvalue_refwrapper;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(&oo2.value() == &o);
+
+    beman::optional26::optional<const O&> oo3 = std::ref(o);
+    EXPECT_TRUE(oo3.has_value());
+    oo3 = std::ref(o);
+    EXPECT_TRUE(oo3.has_value());
+    EXPECT_TRUE(&oo3.value() == &o);
+
+    beman::optional26::optional<const O&> oo4 = lvalue_refwrapper;
+    EXPECT_TRUE(oo4.has_value());
+    oo4 = lvalue_refwrapper;
+    EXPECT_TRUE(oo4.has_value());
+    EXPECT_TRUE(&oo4.value() == &o);
+}

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -696,3 +696,11 @@ TEST(OptionalRefTest, ConstructFromReferenceWrapper) {
     EXPECT_TRUE(oo4.has_value());
     EXPECT_TRUE(&oo4.value() == &o);
 }
+
+TEST(OptionalRefTest, OverloadResolutionChecksDangling) {
+    extern int  check_dangling(beman::optional26::optional<const std::string&>);
+    extern void check_dangling(beman::optional26::optional<const char*>);
+    std::string lvalue_string = "abc";
+    static_assert(std::is_same_v<decltype(check_dangling(lvalue_string)), int>);
+    static_assert(std::is_same_v<decltype(check_dangling("abc")), void>);
+}

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -647,11 +647,17 @@ TEST(OptionalRefTest, ConstructFromOptional) {
 TEST(OptionalRefTest, OptionalOfOptional) {
     using O = beman::optional26::optional<int>;
     O                               o;
-    beman::optional26::optional<O&> oo = o;
-    EXPECT_TRUE(oo.has_value());
-    oo = o;
-    EXPECT_TRUE(oo.has_value());
-    EXPECT_TRUE(&oo.value() == &o);
+    beman::optional26::optional<O&> oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_TRUE(&oo1.value() == &o);
+
+    beman::optional26::optional<const O&> oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(&oo2.value() == &o);
 }
 
 TEST(OptionalRefTest, ConstructFromReferenceWrapper) {

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -610,30 +610,34 @@ TEST(OptionalRefTest, ConstructFromOptional) {
     int                               var = 42;
     beman::optional26::optional<int&> o1  = beman::optional26::nullopt;
     beman::optional26::optional<int&> o2{var};
+    EXPECT_FALSE(o1.has_value());
+    EXPECT_TRUE(o2.has_value());
 
     using beman::optional26::tests::base;
     using beman::optional26::tests::derived;
 
     base                               b{1};
     derived                            d(1, 2);
-    beman::optional26::optional<base&> empty_base;
+    beman::optional26::optional<base&> disengaged_base;
     beman::optional26::optional<base&> engaged_base{b};
+    EXPECT_FALSE(disengaged_base.has_value());
+    EXPECT_TRUE(engaged_base.has_value());
 
-    beman::optional26::optional<derived&> empty_derived_ref;
+    beman::optional26::optional<derived&> disengaged_derived_ref;
     beman::optional26::optional<derived&> engaged_derived_ref{d};
 
-    beman::optional26::optional<base&> optional_base_ref{empty_derived_ref};
+    beman::optional26::optional<base&> optional_base_ref{disengaged_derived_ref};
     EXPECT_FALSE(optional_base_ref.has_value());
 
     beman::optional26::optional<base&> optional_base_ref2{engaged_derived_ref};
     EXPECT_TRUE(optional_base_ref2.has_value());
 
-    beman::optional26::optional<derived> empty_derived;
+    beman::optional26::optional<derived> disengaged_derived;
     beman::optional26::optional<derived> engaged_derived{d};
 
     static_assert(std::is_constructible_v<const base&, derived>);
 
-    beman::optional26::optional<const base&> optional_base_const_ref{empty_derived};
+    beman::optional26::optional<const base&> optional_base_const_ref{disengaged_derived};
     EXPECT_FALSE(optional_base_const_ref.has_value());
 
     beman::optional26::optional<const base&> optional_base_const_ref2{engaged_derived};


### PR DESCRIPTION
There's a lot of commits in this PR — feel free to cherry-pick (but I think they all need to be taken/addressed, one way or another). The really important ones are:

```
commit 4448d97dbd98e017203931e4a9f9a5a8ddb831e8
Author: Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
Date:   Mon Sep 16 13:06:42 2024 -0400

    [test] Add a green test for overload resolution

commit 986b975ad718613351aa1fe4ce20d75e6f956c41
Author: Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
Date:   Mon Sep 16 12:20:19 2024 -0400

    Support optional<T&>::emplace, and add tests
    
    The return type of `emplace` had been wrong; `emplace` returns a
    reference to the emplaced value (in this case, the T& reference
    that was bound), not `*this`.
    
    The new tests are red before the patch and green afterward.

commit a6333d30c8a09c38dae8577f67181a74dbb34e4b
Author: Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
Date:   Mon Sep 16 12:11:47 2024 -0400

    Support binding optional<const T&> to a non-const T, and add tests
    
    The new tests are red before the patch and green afterward.

commit cd93469568a509ac3d2d18904df95e981b196136
Author: Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
Date:   Mon Sep 16 11:29:36 2024 -0400

    Support optional<optional<int>&>
    
    Add two new tests: one for `optional<optional<int>&>`, and one
    testing that we can construct and assign to `optional<T&>` from
    `reference_wrapper<T>` (which should work: since `reference_wrapper<T>`
    is implicitly convertible to `T&`, it also should be implicitly
    convertible to `optional<T&>`).
    These tests are both red before this patch and green afterward.
```

These also correspond to bugs and/or typos in P2988's wording; for example it has `emplace` returning `optional&` instead of `T&`.