### PR TITLE
Prevent calling make_optional<int&>(i) or make_optional<const int&>(i)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI Tests
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,7 @@
 name: pre-commit
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]

--- a/include/Beman/Optional26/optional.hpp
+++ b/include/Beman/Optional26/optional.hpp
@@ -1095,6 +1095,12 @@ class optional<T&> {
         requires detail::safely_convertible<T&, U&>
         : value_(rhs ? std::addressof(static_cast<T&>(*rhs)) : nullptr) {}
 
+    /// Binds the stored reference in-place using the given argument.
+    template <class U>
+    constexpr optional(in_place_t, U&& u)
+        requires detail::safely_constructible<T&, U&&>
+        : value_(std::addressof(static_cast<T&>(std::forward<U>(u)))) {}
+
     //  \rSec3[optional.dtor]{Destructor}
 
     ~optional() = default;

--- a/include/Beman/Optional26/optional.hpp
+++ b/include/Beman/Optional26/optional.hpp
@@ -339,7 +339,7 @@ class optional {
         }
     }
 
-    constexpr optional(const optional&)
+    optional(const optional&)
         requires std::is_copy_constructible_v<T> && std::is_trivially_copy_constructible_v<T>
     = default;
 
@@ -352,7 +352,7 @@ class optional {
         }
     }
 
-    constexpr optional(optional&&)
+    optional(optional&&)
         requires std::is_move_constructible_v<T> && std::is_trivially_move_constructible_v<T>
     = default;
 
@@ -430,7 +430,7 @@ class optional {
         return *this;
     }
 
-    constexpr optional& operator=(const optional&)
+    optional& operator=(const optional&)
         requires std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T> &&
                      std::is_trivially_copy_constructible_v<T> && std::is_trivially_copy_assignable_v<T>
     = default;
@@ -448,7 +448,7 @@ class optional {
         return *this;
     }
 
-    constexpr optional& operator=(optional&&)
+    optional& operator=(optional&&)
         requires std::is_move_constructible_v<T> && std::is_move_assignable_v<T> &&
                      std::is_trivially_move_constructible_v<T> && std::is_trivially_move_assignable_v<T>
     = default;
@@ -1016,17 +1016,17 @@ class optional<T&> {
     // constexpr void reset() noexcept;
 
   private:
-    T* value_; // exposition only
+    T* value_ = nullptr; // exposition only
 
   public:
     //  \rSec3[optional.ctor]{Constructors}
 
-    constexpr optional() noexcept : value_(nullptr) {}
+    optional() = default;
 
     constexpr optional(nullopt_t) noexcept : value_(nullptr) {}
 
-    constexpr optional(const optional& rhs) noexcept = default;
-    constexpr optional(optional&& rhs) noexcept      = default;
+    optional(const optional& rhs) = default;
+    optional(optional&& rhs)      = default;
 
     template <class U = T>
         requires(!detail::is_optional<std::decay_t<U>>)
@@ -1046,7 +1046,7 @@ class optional<T&> {
 
     //  \rSec3[optional.dtor]{Destructor}
 
-    constexpr ~optional() = default;
+    ~optional() = default;
 
     // \rSec3[optional.assign]{Assignment}
 
@@ -1055,8 +1055,8 @@ class optional<T&> {
         return *this;
     }
 
-    constexpr optional& operator=(const optional& rhs) noexcept = default;
-    constexpr optional& operator=(optional&& rhs) noexcept      = default;
+    optional& operator=(const optional&) = default;
+    optional& operator=(optional&&)      = default;
 
     template <class U = T>
         requires(!detail::is_optional<std::decay_t<U>>)
@@ -1078,7 +1078,7 @@ class optional<T&> {
     }
 
     template <class U>
-    constexpr optional& operator=(optional<U>&& rhs) = delete;
+    optional& operator=(optional<U>&& rhs) = delete;
 
     template <class U>
         requires(!detail::is_optional<std::decay_t<U>>)

--- a/include/Beman/Optional26/optional.hpp
+++ b/include/Beman/Optional26/optional.hpp
@@ -232,24 +232,20 @@ template <class T>
 inline constexpr bool is_optional = false;
 template <class T>
 inline constexpr bool is_optional<optional<T>> = true;
+
+struct specification_barrier {
+    explicit specification_barrier() = default;
+};
 } // namespace detail
 
-template <typename T = void,
-          typename... Chomp,
-          typename U,
-          typename D = std::conditional_t<std::is_void_v<T>, std::decay_t<U>, T>>
-constexpr optional<D> make_optional(U&& u) noexcept(std::is_nothrow_constructible_v<D, U>)
-    requires std::is_constructible_v<D, U>
+template <detail::specification_barrier = detail::specification_barrier(), class T>
+constexpr optional<std::decay_t<T>> make_optional(T&& t) noexcept(std::is_nothrow_constructible_v<std::decay_t<T>, T>)
+    requires std::is_constructible_v<std::decay_t<T>, T>
 {
-    static_assert(sizeof...(Chomp) == 0, "make_optional takes at most one template argument");
-    if constexpr (!std::is_void_v<T>) {
-        static_assert(std::is_object_v<T>, "make_optional's template argument must be an object type");
-        static_assert(!std::is_array_v<T>, "make_optional's template argument must be a non-array object type");
-    }
-    return optional<D>(std::forward<U>(u));
+    return optional<std::decay_t<T>>(std::forward<T>(t));
 }
 
-template <typename T, typename... Args>
+template <class T, class... Args>
 constexpr optional<T> make_optional(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args...>)
     requires std::is_constructible_v<T, Args...>
 {
@@ -258,7 +254,7 @@ constexpr optional<T> make_optional(Args&&... args) noexcept(std::is_nothrow_con
     return optional<T>(in_place, std::forward<Args>(args)...);
 }
 
-template <typename T, typename U, typename... Args>
+template <class T, class U, class... Args>
 constexpr optional<T>
 make_optional(std::initializer_list<U> il,
               Args&&... args) noexcept(std::is_nothrow_constructible_v<T, std::initializer_list<U>&, Args...>)

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -371,7 +371,7 @@ TEST(OptionalTest, MakeOptional) {
     EXPECT_TRUE(std::get<1>(o5->t) == 3);
 
     auto i  = 42;
-    auto o6 = beman::optional26::make_optional<int&>(i);
+    auto o6 = beman::optional26::make_optional(i);
     static_assert(std::is_same<decltype(o6), beman::optional26::optional<int>>::value);
 
     EXPECT_TRUE((std::is_same<decltype(o6), beman::optional26::optional<int>>::value));

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -118,6 +118,22 @@ TEST(OptionalTest, NonDefaultConstruct) {
     std::ignore = v2;
 }
 
+TEST(OptionalTest, OptionalOfOptional) {
+    using O = beman::optional26::optional<int>;
+    O                              o;
+    beman::optional26::optional<O> oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_FALSE(oo1->has_value());
+
+    beman::optional26::optional<O> oo2 = std::move(o);
+    EXPECT_TRUE(oo2.has_value());
+    oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_FALSE(oo2->has_value());
+}
+
 TEST(OptionalTest, AssignmentValue) {
     beman::optional26::optional<int> o1 = 42;
     beman::optional26::optional<int> o2 = 12;

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -123,7 +123,7 @@ TEST(OptionalTest, AssignmentValue) {
     beman::optional26::optional<int> o2 = 12;
     beman::optional26::optional<int> o3;
 
-    o1 = o1;
+    o1 = static_cast<beman::optional26::optional<int>&>(o1);
     EXPECT_TRUE(*o1 == 42);
 
     o1 = o2;

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -132,6 +132,23 @@ TEST(OptionalTest, OptionalOfOptional) {
     oo2 = o;
     EXPECT_TRUE(oo2.has_value());
     EXPECT_FALSE(oo2->has_value());
+
+    // emplace constructs the inner optional
+    oo2.emplace(beman::optional26::nullopt);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_FALSE(oo2->has_value());
+    oo2.emplace(beman::optional26::in_place, 41);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(oo2.value() == 41);
+    oo2.emplace(42);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(oo2.value() == 42);
+    oo2.emplace(o);
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_FALSE(oo2->has_value());
+    oo2.emplace(O(43));
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(oo2.value() == 43);
 }
 
 TEST(OptionalTest, AssignmentValue) {

--- a/src/Beman/Optional26/tests/optional_constexpr.t.cpp
+++ b/src/Beman/Optional26/tests/optional_constexpr.t.cpp
@@ -109,6 +109,7 @@ class NoDefault {
 
   public:
     constexpr NoDefault(int v) : v_(v) {}
+    constexpr int value() const { return v_; }
 };
 } // namespace
 
@@ -126,7 +127,7 @@ consteval bool testConstexprAssignmentValue() {
     beman::optional26::optional<int> o2     = 12;
     beman::optional26::optional<int> o3;
 
-    o1 = o1;
+    o1 = static_cast<beman::optional26::optional<int>&>(o1);
     retval &= (*o1 == 42);
 
     o1 = o2;

--- a/src/Beman/Optional26/tests/optional_constexpr.t.cpp
+++ b/src/Beman/Optional26/tests/optional_constexpr.t.cpp
@@ -241,10 +241,9 @@ TEST(OptionalConstexprTest, MakeOptional) {
     EXPECT_TRUE(std::get<1>(o5->t) == 3);
 
     static constexpr auto i  = 42;
-    constexpr auto        o6 = beman::optional26::make_optional<const int&>(i);
-    static_assert(std::is_same<decltype(o6), const beman::optional26::optional<int>>::value);
+    constexpr auto        o6 = beman::optional26::make_optional(i);
+    static_assert(std::is_same_v<decltype(o6), const beman::optional26::optional<int>>);
 
-    EXPECT_TRUE((std::is_same<decltype(o6), const beman::optional26::optional<int>>::value));
     EXPECT_TRUE(o6);
     EXPECT_TRUE(*o6 == 42);
 }

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -81,10 +81,11 @@ TEST(OptionalRefTest, Assignment) {
     EXPECT_FALSE(empty);
     i2 = empty;
     EXPECT_FALSE(i2);
-    int eight = 8;
-    empty.emplace(eight);
+    int  eight  = 8;
+    int& result = empty.emplace(eight);
     EXPECT_TRUE(empty);
     EXPECT_EQ(empty, 8);
+    EXPECT_EQ(&result, &eight);
 }
 
 TEST(OptionalRefTest, RelationalOps) {
@@ -652,10 +653,16 @@ TEST(OptionalRefTest, OptionalOfOptional) {
     oo1 = o;
     EXPECT_TRUE(oo1.has_value());
     EXPECT_TRUE(&oo1.value() == &o);
+    oo1.emplace(o); // emplace, like assignment, binds the reference
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_TRUE(&oo1.value() == &o);
 
     beman::optional26::optional<const O&> oo2 = o;
     EXPECT_TRUE(oo2.has_value());
     oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(&oo2.value() == &o);
+    oo2.emplace(o);
     EXPECT_TRUE(oo2.has_value());
     EXPECT_TRUE(&oo2.value() == &o);
 }

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -643,3 +643,43 @@ TEST(OptionalRefTest, ConstructFromOptional) {
     beman::optional26::optional<const base&> optional_base_const_ref2{engaged_derived};
     EXPECT_TRUE(optional_base_const_ref2.has_value());
 }
+
+TEST(OptionalRefTest, OptionalOfOptional) {
+    using O = beman::optional26::optional<int>;
+    O                               o;
+    beman::optional26::optional<O&> oo = o;
+    EXPECT_TRUE(oo.has_value());
+    oo = o;
+    EXPECT_TRUE(oo.has_value());
+    EXPECT_TRUE(&oo.value() == &o);
+}
+
+TEST(OptionalRefTest, ConstructFromReferenceWrapper) {
+    using O = beman::optional26::optional<int>;
+    O o;
+
+    beman::optional26::optional<O&> oo1 = std::ref(o);
+    EXPECT_TRUE(oo1.has_value());
+    oo1 = std::ref(o);
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_TRUE(&oo1.value() == &o);
+
+    auto                            lvalue_refwrapper = std::ref(o);
+    beman::optional26::optional<O&> oo2               = lvalue_refwrapper;
+    EXPECT_TRUE(oo2.has_value());
+    oo2 = lvalue_refwrapper;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(&oo2.value() == &o);
+
+    beman::optional26::optional<const O&> oo3 = std::ref(o);
+    EXPECT_TRUE(oo3.has_value());
+    oo3 = std::ref(o);
+    EXPECT_TRUE(oo3.has_value());
+    EXPECT_TRUE(&oo3.value() == &o);
+
+    beman::optional26::optional<const O&> oo4 = lvalue_refwrapper;
+    EXPECT_TRUE(oo4.has_value());
+    oo4 = lvalue_refwrapper;
+    EXPECT_TRUE(oo4.has_value());
+    EXPECT_TRUE(&oo4.value() == &o);
+}

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -696,3 +696,11 @@ TEST(OptionalRefTest, ConstructFromReferenceWrapper) {
     EXPECT_TRUE(oo4.has_value());
     EXPECT_TRUE(&oo4.value() == &o);
 }
+
+TEST(OptionalRefTest, OverloadResolutionChecksDangling) {
+    extern int  check_dangling(beman::optional26::optional<const std::string&>);
+    extern void check_dangling(beman::optional26::optional<const char*>);
+    std::string lvalue_string = "abc";
+    static_assert(std::is_same_v<decltype(check_dangling(lvalue_string)), int>);
+    static_assert(std::is_same_v<decltype(check_dangling("abc")), void>);
+}

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -647,11 +647,17 @@ TEST(OptionalRefTest, ConstructFromOptional) {
 TEST(OptionalRefTest, OptionalOfOptional) {
     using O = beman::optional26::optional<int>;
     O                               o;
-    beman::optional26::optional<O&> oo = o;
-    EXPECT_TRUE(oo.has_value());
-    oo = o;
-    EXPECT_TRUE(oo.has_value());
-    EXPECT_TRUE(&oo.value() == &o);
+    beman::optional26::optional<O&> oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    oo1 = o;
+    EXPECT_TRUE(oo1.has_value());
+    EXPECT_TRUE(&oo1.value() == &o);
+
+    beman::optional26::optional<const O&> oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    oo2 = o;
+    EXPECT_TRUE(oo2.has_value());
+    EXPECT_TRUE(&oo2.value() == &o);
 }
 
 TEST(OptionalRefTest, ConstructFromReferenceWrapper) {

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -610,30 +610,34 @@ TEST(OptionalRefTest, ConstructFromOptional) {
     int                               var = 42;
     beman::optional26::optional<int&> o1  = beman::optional26::nullopt;
     beman::optional26::optional<int&> o2{var};
+    EXPECT_FALSE(o1.has_value());
+    EXPECT_TRUE(o2.has_value());
 
     using beman::optional26::tests::base;
     using beman::optional26::tests::derived;
 
     base                               b{1};
     derived                            d(1, 2);
-    beman::optional26::optional<base&> empty_base;
+    beman::optional26::optional<base&> disengaged_base;
     beman::optional26::optional<base&> engaged_base{b};
+    EXPECT_FALSE(disengaged_base.has_value());
+    EXPECT_TRUE(engaged_base.has_value());
 
-    beman::optional26::optional<derived&> empty_derived_ref;
+    beman::optional26::optional<derived&> disengaged_derived_ref;
     beman::optional26::optional<derived&> engaged_derived_ref{d};
 
-    beman::optional26::optional<base&> optional_base_ref{empty_derived_ref};
+    beman::optional26::optional<base&> optional_base_ref{disengaged_derived_ref};
     EXPECT_FALSE(optional_base_ref.has_value());
 
     beman::optional26::optional<base&> optional_base_ref2{engaged_derived_ref};
     EXPECT_TRUE(optional_base_ref2.has_value());
 
-    beman::optional26::optional<derived> empty_derived;
+    beman::optional26::optional<derived> disengaged_derived;
     beman::optional26::optional<derived> engaged_derived{d};
 
     static_assert(std::is_constructible_v<const base&, derived>);
 
-    beman::optional26::optional<const base&> optional_base_const_ref{empty_derived};
+    beman::optional26::optional<const base&> optional_base_const_ref{disengaged_derived};
     EXPECT_FALSE(optional_base_const_ref.has_value());
 
     beman::optional26::optional<const base&> optional_base_const_ref2{engaged_derived};

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -387,6 +387,13 @@ TEST(OptionalRefTest, MakeOptional) {
     EXPECT_TRUE((std::is_same_v<decltype(o6), beman::optional26::optional<int>>));
     EXPECT_TRUE(o6);
     EXPECT_TRUE(*o6 == 42);
+
+    // Test the surprising misbehavior of make_optional.
+    auto co1 = beman::optional26::make_optional<int&>(var);
+    auto co2 = beman::optional26::make_optional<const int&>(var);
+
+    static_assert(std::is_same_v<decltype(co1), beman::optional26::optional<int>>);
+    static_assert(std::is_same_v<decltype(co2), beman::optional26::optional<const int&>>);
 }
 
 TEST(OptionalRefTest, Nullopt) {

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -350,52 +350,6 @@ struct takes_init_and_variadic {
     takes_init_and_variadic(std::initializer_list<int> l, Args&&... args) : v(l), t(std::forward<Args>(args)...) {}
 };
 
-TEST(OptionalRefTest, MakeOptional) {
-    int  var{42};
-    auto o1 = beman::optional26::make_optional<int&>(var);
-    auto o2 = beman::optional26::optional<int&>(var);
-
-    constexpr bool is_same = std::is_same<decltype(o1), beman::optional26::optional<int>>::value;
-    EXPECT_TRUE(is_same);
-    EXPECT_TRUE(o1 == o2);
-
-    std::tuple<int, int, int, int> tvar{0, 1, 2, 3};
-    auto                           o3 = beman::optional26::make_optional<std::tuple<int, int, int, int>&>(tvar);
-    EXPECT_TRUE(std::get<0>(*o3) == 0);
-    EXPECT_TRUE(std::get<1>(*o3) == 1);
-    EXPECT_TRUE(std::get<2>(*o3) == 2);
-    EXPECT_TRUE(std::get<3>(*o3) == 3);
-
-    std::vector<int> ivec{0, 1, 2, 3};
-    auto             o4 = beman::optional26::make_optional<std::vector<int>&>(ivec);
-    EXPECT_TRUE(o4.value()[0] == 0);
-    EXPECT_TRUE(o4.value()[1] == 1);
-    EXPECT_TRUE(o4.value()[2] == 2);
-    EXPECT_TRUE(o4.value()[3] == 3);
-
-    takes_init_and_variadic tiv{{0, 1}, 2, 3};
-    auto                    o5 = beman::optional26::make_optional<takes_init_and_variadic&>(tiv);
-    EXPECT_TRUE(o5->v[0] == 0);
-    EXPECT_TRUE(o5->v[1] == 1);
-    EXPECT_TRUE(std::get<0>(o5->t) == 2);
-    EXPECT_TRUE(std::get<1>(o5->t) == 3);
-
-    auto i  = 42;
-    auto o6 = beman::optional26::make_optional<int&>(i);
-    static_assert(std::is_same_v<decltype(o6), beman::optional26::optional<int>>);
-
-    EXPECT_TRUE((std::is_same_v<decltype(o6), beman::optional26::optional<int>>));
-    EXPECT_TRUE(o6);
-    EXPECT_TRUE(*o6 == 42);
-
-    // Test the surprising misbehavior of make_optional.
-    auto co1 = beman::optional26::make_optional<int&>(var);
-    auto co2 = beman::optional26::make_optional<const int&>(var);
-
-    static_assert(std::is_same_v<decltype(co1), beman::optional26::optional<int>>);
-    static_assert(std::is_same_v<decltype(co2), beman::optional26::optional<const int&>>);
-}
-
 TEST(OptionalRefTest, Nullopt) {
     beman::optional26::optional<int&> o1 = beman::optional26::nullopt;
     beman::optional26::optional<int&> o2{beman::optional26::nullopt};

--- a/src/Beman/Optional26/tests/optional_ref.t.cpp
+++ b/src/Beman/Optional26/tests/optional_ref.t.cpp
@@ -704,3 +704,13 @@ TEST(OptionalRefTest, OverloadResolutionChecksDangling) {
     static_assert(std::is_same_v<decltype(check_dangling(lvalue_string)), int>);
     static_assert(std::is_same_v<decltype(check_dangling("abc")), void>);
 }
+
+TEST(OptionalRefTest, OverloadResolutionChecksDangling2) {
+    extern int  check_dangling(beman::optional26::optional<const std::string&>);
+    extern void check_dangling(beman::optional26::optional<const char*&>);
+
+    beman::optional26::optional<std::string> optional_string  = "abc";
+    beman::optional26::optional<const char*> optional_pointer = "abc";
+    static_assert(std::is_same_v<decltype(check_dangling(optional_string)), int>);
+    static_assert(std::is_same_v<decltype(check_dangling(optional_pointer)), void>);
+}


### PR DESCRIPTION
The status quo in C++23 is that

        int i;
        auto o = make_optional<int&>(i);

produces an `optional<int>`, not an `optional<int&>`. This would be horribly confusing to propagate into C++26 — users would naturally expect to receive an `optional<int&>`. Worse,

        auto o = make_optional<int&>(std::ref(i));

actually *would* give you an `optional<int&>`, because it would use a different overload of `make_optional`! So, we propose to add a "Mandates" element to `make_optional` that requires its explicit template argument (if any) to be a non-array object type.
This breaks the "status quo" example at the top of this comment (requiring an Annex C entry); but it successfully prevents the pitfalls. And it does not _silently change the behavior_ of the "status quo" example, either — which would probably be 100x worse than merely breaking it!

Thanks to Tomasz Kamiński for the template-programming trick, which matches the technique used in https://eel.is/c++draft/out.ptr .