### PR TITLE
Add more compiler support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - {name: "Ubuntu Clang 19", os: ubuntu-24.04, toolchain: "clang-19", clang_version: 19, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" ", asan_options: "new_delete_type_mismatch=0"}
           - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18", clang_version: 18, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17", clang_version: 17, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu Clang 16", os: ubuntu-24.04, toolchain: "clang-16", clang_version: 16, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14", cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17", clang_version: 17, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
-          - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18", clang_version: 18, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu Clang 20", os: ubuntu-24.04, toolchain: "clang-20", clang_version: 20, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           # Note: clang-19 + Asan setup causes errors on some platforms. Temporary skip some checks via .asan_options.
           - {name: "Ubuntu Clang 19", os: ubuntu-24.04, toolchain: "clang-19", clang_version: 19, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" ", asan_options: "new_delete_type_mismatch=0"}
-          - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
-          - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18", clang_version: 18, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17", clang_version: 17, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14", cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - {name: "Ubuntu Clang 19", os: ubuntu-24.04, toolchain: "clang-19", clang_version: 19, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" ", asan_options: "new_delete_type_mismatch=0"}
           - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18", clang_version: 18, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17", clang_version: 17, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
-          - {name: "Ubuntu Clang 16", os: ubuntu-24.04, toolchain: "clang-16", clang_version: 16, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14", cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
           - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,6 +72,13 @@
       "displayName": "Clang 17",
       "description": "Build with Clang 17 compilers",
       "toolchainFile": "${sourceDir}/etc/clang-17-toolchain.cmake"
+    },
+    {
+      "name": "clang-16",
+      "inherits": "common",
+      "displayName": "Clang 16",
+      "description": "Build with Clang 16 compilers",
+      "toolchainFile": "${sourceDir}/etc/clang-16-toolchain.cmake"
     }
   ],
   "buildPresets": [
@@ -119,6 +126,11 @@
       "name": "clang-17",
       "inherits": "common",
       "configurePreset": "clang-17"
+    },
+    {
+      "name": "clang-16",
+      "inherits": "common",
+      "configurePreset": "clang-16"
     }
   ],
   "testPresets": [
@@ -173,6 +185,11 @@
       "name": "clang-17",
       "inherits": "common",
       "configurePreset": "clang-17"
+    },
+    {
+      "name": "clang-16",
+      "inherits": "common",
+      "configurePreset": "clang-16"
     }
   ],
   "workflowPresets": [
@@ -309,6 +326,23 @@
         {
           "type": "test",
           "name": "clang-17"
+        }
+      ]
+    },
+    {
+      "name": "clang-16",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "clang-16"
+        },
+        {
+          "type": "build",
+          "name": "clang-16"
+        },
+        {
+          "type": "test",
+          "name": "clang-16"
         }
       ]
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,6 +39,20 @@
       "toolchainFile": "${sourceDir}/etc/gcc-13-toolchain.cmake"
     },
     {
+      "name": "gcc-12",
+      "inherits": "common",
+      "displayName": "GCC 12",
+      "description": "Build with GCC 12 compilers",
+      "toolchainFile": "${sourceDir}/etc/gcc-12-toolchain.cmake"
+    },
+    {
+      "name": "clang-20",
+      "inherits": "common",
+      "displayName": "Clang 20",
+      "description": "Build with Clang 20 compilers",
+      "toolchainFile": "${sourceDir}/etc/clang-20-toolchain.cmake"
+    },
+    {
       "name": "clang-19",
       "inherits": "common",
       "displayName": "Clang 19",
@@ -80,6 +94,16 @@
       "name": "gcc-13",
       "inherits": "common",
       "configurePreset": "gcc-13"
+    },
+    {
+      "name": "gcc-12",
+      "inherits": "common",
+      "configurePreset": "gcc-12"
+    },
+    {
+      "name": "clang-20",
+      "inherits": "common",
+      "configurePreset": "clang-20"
     },
     {
       "name": "clang-19",
@@ -124,6 +148,16 @@
       "name": "gcc-13",
       "inherits": "common",
       "configurePreset": "gcc-13"
+    },
+    {
+      "name": "gcc-12",
+      "inherits": "common",
+      "configurePreset": "gcc-12"
+    },
+    {
+      "name": "clang-20",
+      "inherits": "common",
+      "configurePreset": "clang-20"
     },
     {
       "name": "clang-19",
@@ -190,6 +224,40 @@
         {
           "type": "test",
           "name": "gcc-13"
+        }
+      ]
+    },
+    {
+      "name": "gcc-12",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "gcc-12"
+        },
+        {
+          "type": "build",
+          "name": "gcc-12"
+        },
+        {
+          "type": "test",
+          "name": "gcc-12"
+        }
+      ]
+    },
+    {
+      "name": "clang-20",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "clang-20"
+        },
+        {
+          "type": "build",
+          "name": "clang-20"
+        },
+        {
+          "type": "test",
+          "name": "clang-20"
         }
       ]
     },

--- a/etc/clang-20-toolchain.cmake
+++ b/etc/clang-20-toolchain.cmake
@@ -1,3 +1,8 @@
+# cmake-format: off
+# etc/clang-20-toolchain.cmake -*-cmake-*-
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# cmake-format: on
+
 include_guard(GLOBAL)
 
 set(CMAKE_C_COMPILER clang-20)


### PR DESCRIPTION
Partial fix for #77 

- clang-20 full suport (local preset + CI)
- clang-16 partial support (only local preset support; llvm.sh fails to install clang-16 on CI).

More discussions will be done in https://github.com/beman-project/beman/issues/34.  This PR just allows us to tests on more setups.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/5107d7bd-ed9a-4095-b920-08c22f2ad477">

